### PR TITLE
Bump to eclipse 2023 06

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.3</version>
+		<version>3.0.4</version>
 	</extension>
 </extensions>

--- a/plugins/gexpressions/org.eclipse.gemoc.gexpressions.xtext/META-INF/MANIFEST.MF
+++ b/plugins/gexpressions/org.eclipse.gemoc.gexpressions.xtext/META-INF/MANIFEST.MF
@@ -17,7 +17,7 @@ Require-Bundle: org.eclipse.xtext;visibility:=reexport,
  org.eclipse.xtext.util,
  org.eclipse.xtext.xbase.lib,
  org.antlr.runtime,
- org.eclipse.xtext.generator;bundle-version="2.27.0"
+ org.eclipse.xtext.xtext.generator;bundle-version="[2.31.0,3.0.0)"
 Import-Package: org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.eclipse.gemoc.gexpressions.xtext,

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-commons.git</tycho.scmUrl>
 		<!-- <sonar.projectKey>gemoc:${project.groupId}:${project.artifactId}</sonar.projectKey>-->	
 				
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<org.mapstruct.version>1.4.2.Final</org.mapstruct.version>
 		<maven.deploy.skip>false</maven.deploy.skip>
 	</properties>
@@ -78,23 +78,20 @@
 							<goal>plugin-source</goal>
 						</goals>
 					</execution>
+					<execution>
+			            <id>feature-source</id>
+			            <goals>
+			              <goal>feature-source</goal>
+			            </goals>
+			            <configuration>
+			              <excludes>
+			                <!-- provide plug-ins not containing any source code -->
+			                <!-- also possible to exclude feature-->
+			              </excludes>
+			            </configuration>
+          			</execution>
 				</executions>
 			</plugin>
-			<!-- enable source feature generation -->
-			<plugin>
-		      <groupId>org.eclipse.tycho.extras</groupId>
-		      <artifactId>tycho-source-feature-plugin</artifactId>
-		      <version>${tycho-version}</version>
-		      <executions>
-		        <execution>
-		          <id>source-feature</id>
-		          <phase>package</phase>
-		          <goals>
-		            <goal>source-feature</goal>
-		          </goals>
-		        </execution>
-		      </executions>
-		    </plugin>
 		    <plugin>
 		     <groupId>org.eclipse.tycho</groupId>
 		     <artifactId>tycho-p2-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,8 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
+				   	<!-- Optional set the Java version you are using-->
+	    		    <executionEnvironment>JavaSE-17</executionEnvironment>
 					<target>
                         <artifact>
                             <groupId>org.eclipse.gemoc.gemoc-studio.bundle</groupId>

--- a/pomfirst/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/pom.xml
+++ b/pomfirst/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/pom.xml
@@ -25,7 +25,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -42,7 +41,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy-resource-src</id>

--- a/pomfirst/org.eclipse.gemoc.commons.eclipse.pde/pom.xml
+++ b/pomfirst/org.eclipse.gemoc.commons.eclipse.pde/pom.xml
@@ -25,7 +25,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -42,7 +41,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy-resource-one</id>

--- a/pomfirst/org.eclipse.gemoc.commons.eclipse/pom.xml
+++ b/pomfirst/org.eclipse.gemoc.commons.eclipse/pom.xml
@@ -25,7 +25,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -42,7 +41,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy-resource-one</id>

--- a/pomfirst/org.eclipse.gemoc.dsl.model/pom.xml
+++ b/pomfirst/org.eclipse.gemoc.dsl.model/pom.xml
@@ -30,7 +30,6 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>3.2.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>
@@ -47,7 +46,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
-				<version>3.0.2</version>
 				<executions>
 					<execution>
 						<id>copy-resource-src</id>

--- a/pomfirst/pom.xml
+++ b/pomfirst/pom.xml
@@ -33,14 +33,13 @@
 	
 	<properties>
 		<!--<tycho.version>1.5.1</tycho.version>-->
-		<xtend.version>2.25.0</xtend.version>
+		<xtend.version>2.27.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
 		<gemoc-repo.url>https://download.eclipse.org/gemoc/updates/nightly</gemoc-repo.url>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-modeldebugging.git</tycho.scmUrl>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	
 		
@@ -77,6 +76,25 @@
 			</plugin>
 
 		</plugins>
+		
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.codehaus.mojo</groupId>
+					<artifactId>build-helper-maven-plugin</artifactId>
+					<version>3.2.0</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.0.2</version>
+				</plugin>
+	            <plugin>
+	                <groupId>org.apache.maven.plugins</groupId>
+	                <artifactId>maven-compiler-plugin</artifactId>
+	                <version>3.8.1</version>
+	            </plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 
 	<dependencyManagement>

--- a/pomfirst/pom.xml
+++ b/pomfirst/pom.xml
@@ -33,7 +33,7 @@
 	
 	<properties>
 		<!--<tycho.version>1.5.1</tycho.version>-->
-		<xtend.version>2.27.0</xtend.version>
+		<xtend.version>2.31.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
 		<gemoc-repo.url>https://download.eclipse.org/gemoc/updates/nightly</gemoc-repo.url>

--- a/pomfirst/pom.xml
+++ b/pomfirst/pom.xml
@@ -32,13 +32,13 @@
 	</developers>
 	
 	<properties>
-		<tycho.version>1.5.1</tycho.version>
-		<xtend.version>2.18.0</xtend.version>
+		<!--<tycho.version>1.5.1</tycho.version>-->
+		<xtend.version>2.25.0</xtend.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<eclipse-repo.url>http://download.eclipse.org/releases/photon</eclipse-repo.url>
 		<gemoc-repo.url>https://download.eclipse.org/gemoc/updates/nightly</gemoc-repo.url>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<tycho.scmUrl>scm:git:https://github.com/eclipse/gemoc-studio-modeldebugging.git</tycho.scmUrl>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>


### PR DESCRIPTION
## Description

Upgrade the base Eclipse to Eclipse 2023-06.
Applies the changes required by the new version of components (XText, Xtend, Sirius)
New minimal requirement : java 17

## Changes

<!-- more details , changed documentation sections, changed version, some details about the code changes -->
 
 - Use java 17 in the CI docker image
 - new splash screen
 - use tycho 3.0.4
 - use xtend 2.31
 - use lsp4j 0.21
 - change maven plugin for generating plantuml images
 - fix melangeK3FSM project nature
 - replace org.eclipse.xtext.generator by org.eclipse.xtext.xtext.generator in moccml
 - remove use of deprecated xtext.MergeableManifest
 
## Contribution to issues

Contribute to #298 

## Companion Pull Requests

 - https://github.com/eclipse/gemoc-studio/pull/299
 - https://github.com/eclipse/gemoc-studio-modeldebugging/pull/232
 - https://github.com/eclipse/gemoc-studio-execution-ale/pull/61
 - https://github.com/eclipse/gemoc-studio-execution-java/pull/32
 - https://github.com/eclipse/gemoc-studio-execution-moccml/pull/77
 - https://github.com/eclipse/gemoc-studio-moccml/pull/28
 - https://github.com/eclipse/gemoc-studio-commons/pull/4
