### PR TITLE
Enhance start management of messagingsystem.ui

### DIFF
--- a/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/.classpath
+++ b/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java/"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.api/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.gemoc.commons.eclipse.messagingsystem.api;singl
 Bundle-Version: 3.3.0.qualifier
 Bundle-Vendor: Eclipse GEMOC Project
 Require-Bundle: org.eclipse.core.runtime
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .
 Export-Package: org.eclipse.gemoc.commons.eclipse.messagingsystem.api,

--- a/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/.classpath
+++ b/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java/"/>
 	<classpathentry kind="output" path="target/classes"/>

--- a/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
-org.eclipse.jdt.core.compiler.compliance=1.6
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.6
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=17

--- a/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.gemoc.commons.eclipse.messagingsystem.ui/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.core.resources,
  org.eclipse.ui.editors,
  org.eclipse.gemoc.commons.eclipse.messagingsystem.api;bundle-version="1.0.0",
  org.eclipse.swt
-Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.eclipse.gemoc.commons.eclipse.messagingsystem.ui
 Automatic-Module-Name: org.eclipse.gemoc.commons.eclipse.messagingsystem.ui
 


### PR DESCRIPTION
Ensures preferenceStore() is accessed in the start method. 

Ensures getConsoleIO is fully initialize before trying to send message to it from other plugins.
This avoids some deadlock

contributes to https://github.com/eclipse/gemoc-studio-commons/issues/6



